### PR TITLE
Make --split optional and default download both split

### DIFF
--- a/download_data.py
+++ b/download_data.py
@@ -216,7 +216,8 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--split",
-        choices=["Training", "Validation"],
+        choices=[None, "Training", "Validation"],
+        default=None
     )
 
     parser.add_argument(


### PR DESCRIPTION
Hi @arik1089, how time flies, it has been two years since the last time I created a PR  for ArkitScene. This PR intended to make `--split` optional and default download both Training and Validation split. It is better to let users think less about setting parameters for downloading a dataset.